### PR TITLE
fix: avoid globalThis.crypto error

### DIFF
--- a/packages/vscode-typescript-repl/src/vm.ts
+++ b/packages/vscode-typescript-repl/src/vm.ts
@@ -86,6 +86,16 @@ export const assignGlobal = (context: vm.Context) => {
   const globalDescriptors = Object.getOwnPropertyNames(_global)
   globalDescriptors.forEach((k) => {
     if (!globalBuiltinNames.has(k)) {
+      // this requires special handling due to a globalThis check
+      // that node 18 implements by default
+      if (k === "crypto") {
+        Object.defineProperty(context, 'crypto', {
+          ...Object.getOwnPropertyDescriptor(_global, 'crypto'),
+          get: () => require('crypto').webcrypto
+
+        })
+        return
+      }
       Object.defineProperty(context, k, {
         // @ts-expect-error
         __proto__: null,

--- a/packages/vscode-typescript-repl/src/vm.ts
+++ b/packages/vscode-typescript-repl/src/vm.ts
@@ -88,6 +88,7 @@ export const assignGlobal = (context: vm.Context) => {
     if (!globalBuiltinNames.has(k)) {
       // this requires special handling due to a globalThis check
       // that node 18 implements by default
+      // https://github.com/alex-dixon/vscode-typescript-repl/issues/15
       if (k === "crypto") {
         Object.defineProperty(context, 'crypto', {
           ...Object.getOwnPropertyDescriptor(_global, 'crypto'),


### PR DESCRIPTION
#15 

more recent versions of vscode use a version of electron that uses node >=18, which changes the way the global context can be cloned. this fixes it by creating a getter that satisfies the expected interface while not requring a "globalThis" check on access.